### PR TITLE
Use images directly from the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ You can use it to make a bootable GNU/Linux USB drive when your laptop is dead a
 
 ## Screenshots
 
-<img
-src="metadata/en-US/images/phoneScreenshots/0.png" width="100" height="178"> <img
-src="metadata/en-US/images/phoneScreenshots/2.png" width="100" height="178"> <img
-src="metadata/en-US/images/phoneScreenshots/3.png" width="100" height="178"> <img
-src="metadata/en-US/images/phoneScreenshots/4.png" width="100" height="178"> <img
-src="metadata/en-US/images/phoneScreenshots/5.png" width="100" height="178"> <img
-src="metadata/en-US/images/phoneScreenshots/6.png" width="100" height="178">
+<!-- Exact dimensions are specified to avoid the images jumping as they load -->
+<!-- The "force inline" comment ensures the images stay inline, the fact that it's needed might be a GFM bug -->
+<img src="metadata/en-US/images/phoneScreenshots/0.png" width="100" height="178"> <!-- Force inline -->
+<img src="metadata/en-US/images/phoneScreenshots/2.png" width="100" height="178"> <!-- Force inline -->
+<img src="metadata/en-US/images/phoneScreenshots/3.png" width="100" height="178"> <!-- Force inline -->
+<img src="metadata/en-US/images/phoneScreenshots/4.png" width="100" height="178"> <!-- Force inline -->
+<img src="metadata/en-US/images/phoneScreenshots/5.png" width="100" height="178"> <!-- Force inline -->
+<img src="metadata/en-US/images/phoneScreenshots/6.png" width="100" height="178"> <!-- Force inline -->
 
 ## Support the project
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ You can use it to make a bootable GNU/Linux USB drive when your laptop is dead a
 
 ## Screenshots
 
-[![screenshot0.png](https://s22.postimg.cc/pzx4pygy5/image.png)](https://postimg.cc/image/pzx4pygy5/) [![screenshot1.png](https://s22.postimg.cc/o845v25b1/image.png)](https://postimg.cc/image/o845v25b1/) [![screenshot2.png](https://s22.postimg.cc/cj0673m25/image.png)](https://postimg.cc/image/cj0673m25/) [![screenshot3.png](https://s22.postimg.cc/c68s0xbi5/image.png)](https://postimg.cc/image/c68s0xbi5/) [![screenshot4.png](https://s22.postimg.cc/77l9men4t/image.png)](https://postimg.cc/image/77l9men4t/) [![screenshot5.png](https://s22.postimg.cc/3nzbwlcp9/image.png)](https://postimg.cc/image/3nzbwlcp9/)
+<img
+src="metadata/en-US/images/phoneScreenshots/0.png" width="100" height="178"> <img
+src="metadata/en-US/images/phoneScreenshots/2.png" width="100" height="178"> <img
+src="metadata/en-US/images/phoneScreenshots/3.png" width="100" height="178"> <img
+src="metadata/en-US/images/phoneScreenshots/4.png" width="100" height="178"> <img
+src="metadata/en-US/images/phoneScreenshots/5.png" width="100" height="178"> <img
+src="metadata/en-US/images/phoneScreenshots/6.png" width="100" height="178">
 
 ## Support the project
 


### PR DESCRIPTION
Closes #41.

I don't know why, but when I used this syntax:

```md
<img>
<img>
<img>
```

The images appeared one on top of another even though they should have showed up inline. Definitely weird.

I "fixed" it by appending an HTML comment after each one which resulted in the expected layout.
I have no idea if this is a GFM issue or just a MarkDown thing in general.

In any case, it's no big deal IMO and now you can drop a dependency on a 3rd party image hoster.