### PR TITLE
Useless translations

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">EtchDroid</string>
     <string name="flash_dd_usb_api">Abbild direkt auf Datenträger schreiben (mithilfe der Android API)</string>
     <string name="flash_dmg_api">macOS DMG Abbild auf Datenträger wiederherstellen (mithilfe der Android API)</string>
     <string name="flash_unetbootin">Flash im Unetbootin-Stil (nur MBR, benötigt root)</string>
@@ -20,38 +19,13 @@
     <string name="notif_initializing">Initialisierung…</string>
     <string name="notif_writing_img">Schreibt Abbild…</string>
     <string name="image_is_not_dmg">Ausgewähltes Abbild ist kein DMG Abbild (vielleicht ist es beschädigt)</string>
-    <string name="ptt_aix">IBM AIX</string>
-    <string name="ptt_amiga">AMIGA</string>
-    <string name="ptt_bsd">BSD</string>
-    <string name="ptt_dvh">DVH</string>
     <string name="ptt_gpt">GUID Partitionstabelle (GPT)</string>
     <string name="ptt_loop">Keiner</string>
     <string name="ptt_mac">Apple Partitionstabelle (APT)</string>
-    <string name="ptt_msdos">Master Boot Record (MSDOS)</string>
-    <string name="ptt_pc98">PC98</string>
-    <string name="ptt_sun">Sun</string>
-    <string name="fs_fat12">FAT12</string>
-    <string name="fs_fat16">FAT16</string>
-    <string name="fs_fat32">FAT32</string>
-    <string name="fs_exfat">ExFAT</string>
-    <string name="fs_ntfs">NTFS</string>
-    <string name="fs_refs">ReFS</string>
-    <string name="fs_hfs">macOS HFS</string>
-    <string name="fs_hfsplus">macOS HFS+</string>
-    <string name="fs_apfs">Apple Filesystem (APFS)</string>
     <string name="fs_apt_data">APT-Daten</string>
-    <string name="fs_iso9660">ISO 9660</string>
-    <string name="fs_ext2">Linux Ext2</string>
-    <string name="fs_ext3">Linux Ext3</string>
-    <string name="fs_ext4">Linux Ext4</string>
-    <string name="fs_btrfs">Btrfs</string>
-    <string name="fs_f2fs">f2fs</string>
     <string name="fs_luks">LUKS verschlüsselt</string>
     <string name="fs_linux_swap">Linux swap</string>
     <string name="fs_linux_lvm_pv">Linux LVM2 physischer Datenträger</string>
-    <string name="fs_ufs">UFS</string>
-    <string name="fs_xfs">XFS</string>
-    <string name="fs_zfs">ZFS</string>
     <string name="fs_free">Freier Platz</string>
     <string name="fs_unformatted">Unformatiert</string>
     <string name="fs_unknown">Unbekannt</string>
@@ -59,11 +33,8 @@
     <string name="fs_label">Beschriftung</string>
     <string name="fs_type">Typ</string>
     <string name="part_size">Größe</string>
-    <string name="license_gpl3_name">GNU GPLv3</string>
     <string name="this_app">Diese app</string>
-    <string name="license_apache_name">Apache 2.0</string>
     <string name="libaums_desc">Userspace USB Block Gerät Implementation</string>
-    <string name="license_gpl2">GNU GPLv2</string>
     <string name="license_bzip2">BSD-ähnlich</string>
     <string name="license_custom">personalisierte</string>
     <string name="about">Über</string>
@@ -87,7 +58,6 @@
     <string name="dataloss_confirmation_dialog_message">Wenn du fortfährst, wird das ausgewählte Abbild geschrieben und alle Daten auf dem USB-Datenträger gehen für immer verloren!</string>
     <string name="warning">Warnung</string>
     <string name="cancel">Abbrechen</string>
-    <string name="license_mpl_2_0">MPL-2.0</string>
     <string name="storagechooser_desc">DMG Dateiwähler</string>
     <string name="result_channel_desc">Zeigt das Ergebnis einer fertigen Schreiboperation an</string>
     <string name="result_channel_name">USB Schreibergebnis Benachrichtigungen</string>
@@ -97,17 +67,7 @@
     <string name="success_notif_content_text">%1$s wurde erfolgreich auf %2$s geschrieben</string>
     <string name="troubleshooting_info">Informationen zur Fehlerbehebung</string>
     <string name="operation_failed_because">Die Operation konnte nicht fertiggestellt werden, da der folgende Fehler aufgetreten ist:</string>
-    <string name="troubleshoot_sock_op_on_non_sock">Dies ist ein häufiger Fehler. Er passiert normalerweise, wenn der USB-Datenträger während des Schreibens entfernt wird, oder wenn er mit einem USB-Hub verbunden ist. Auf manchen Geräten existiert möglicherweise ein Bug im USB-Subsystem von Android: ein Neustart des Geräts sollte es für einige Zeit beheben. 
-\n
-\nVersuche folgendes:
-\n• USB-Gerät abstecken und wieder anstecken, dann die App neu starten
-\n• Gerät neu starten (ernsthaft, versuche es)
-\n• Anderes USB-Gerät ausprobieren
-\n• Unnötige Adapter und Hubs vermeiden
-\n• Vermeide, dein Smart-Gerät während des Schreibens zu benutzen
-\n• Defekte USB-Adapter austauschen
-\n
-\nWenn das Problem weiterhin auftritt, reiche bitte ein Issue auf GitHub ein.</string>
+
     <string name="reporting_issues">Probleme melden</string>
     <string name="reporting_issues_text">Probleme können auf Github gemeldet werden:\nhttps://github.com/Depau/EtchDroid/issues</string>
     <string name="write_failed">Schreiben fehlgeschlagen</string>
@@ -123,38 +83,12 @@
     <string name="cannot_find_file_in_storage">Datei kann im internen Speicher nicht gefunden werden. Versuche es innerhalb der App zu öffnen.</string>
     <string name="storage_permission_required">Speicherberechtigung ist notwendig, um DMG Abbilder zu lesen</string>
     <!-- AndroidX Jetpack -->
-    <string name="define_AndroidX" translatable="false"/>
-    <string name="library_AndroidX_author" translatable="false">AOSP</string>
-    <string name="library_AndroidX_authorWebsite" translatable="false">https://developer.android.com</string>
-    <string name="library_AndroidX_libraryName" translatable="false">AndroidX Jetpack</string>
     <string name="library_AndroidX_libraryDescription">AndroidX ist eine neue Version der originalen Android Unterstützungs-Bibliothek und gewährleistet Abwärtskompatibilität mit früheren Android-Versionen</string>
-    <string name="library_AndroidX_libraryWebsite">https://developer.android.com/jetpack/androidx/</string>
-    <string name="library_AndroidX_libraryVersion">1.0.1</string>
-    <string name="library_AndroidX_isOpenSource">true</string>
-    <string name="library_AndroidX_repositoryLink">https://android.googlesource.com/platform/frameworks/support/+/androidx-master-dev/</string>
-    <string name="license_androidx_library" translatable="false">apache_2_0</string>
     <!-- Kotlin Standard Library -->
-    <string name="define_KotlinStdlib"/>
-    <string name="library_KotlinStdlib_author">JetBrains</string>
-    <string name="library_KotlinStdlib_authorWebsite">https://kotlinlang.org/</string>
     <string name="library_KotlinStdlib_libraryName">Kotlin Standardbibliothek</string>
     <string name="library_KotlinStdlib_libraryDescription">The Kotlin Standardbibliothek stellt das Notwendigste zur Verfügung, um mit Kotlin zu arbeiten</string>
-    <string name="library_KotlinStdlib_libraryWebsite">https://kotlinlang.org/api/latest/jvm/stdlib/index.html</string>
-    <string name="library_KotlinStdlib_libraryVersion">1.2.71</string>
-    <string name="library_KotlinStdlib_isOpenSource">true</string>
-    <string name="library_KotlinStdlib_repositoryLink">https://github.com/JetBrains/kotlin/tree/master/libraries/stdlib</string>
-    <string name="license_kotlin_stdlib">apache_2_0</string>
     <!-- Material Components -->
-    <string name="define_Material"/>
-    <string name="library_Material_author">Google</string>
-    <string name="library_Material_authorWebsite">https://material.io/develop/</string>
-    <string name="library_Material_libraryName">Material Components</string>
     <string name="library_Material_libraryDescription">Erstelle schöne Produkte, schneller. Material ist ein Designsystem, welches von open-source Code unterstützt wird und Teams beim bauen von digitalen Erfahrungen hilft</string>
-    <string name="library_Material_libraryWebsite">https://material.io/develop/android/</string>
-    <string name="library_Material_libraryVersion">1.1.0-alpha01</string>
-    <string name="library_Material_isOpenSource">true</string>
-    <string name="library_Material_repositoryLink">https://github.com/material-components/material-components-android</string>
-    <string name="license_material_library">apache_2_0</string>
     <string name="app_desc">Eine Anwendung, um Systemabbilder auf USB-Datenträger zu schreiben, auf Android und ohne Root-Pflicht.</string>
     <string name="buy_me_a_coffee">Kaufe mir einen Kaffee</string>
     <string name="step_x_of_y">Schritt %1$d von %2$d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -68,17 +68,7 @@
     <string name="success_notif_content_text">%1$s escrito con éxito a %2$s</string>
     <string name="troubleshooting_info">Información para solucionar problemas</string>
     <string name="operation_failed_because">La operación no pudo completarse porque se produjo el siguiente error:</string>
-    <string name="troubleshoot_sock_op_on_non_sock">Este es un error común. Por lo general, esto sucede cuando la unidad USB está desconectada mientras se está escribiendo, o cuando está conectada a través de un concentrador USB. En algunos dispositivos puede haber un error en el subsistema USB de Android: normalmente un reinicio lo arreglará durante algún tiempo. 
-\n
-\nPruebe esto:
-\n• Desconecte y vuelva a conectar el dispositivo USB, a continuación, reinicie la aplicación.
-\n• Reinicie su dispositivo (realmente probarlo)
-\n• Pruebe otra unidad USB
-\n• Evite el uso de adaptadores, llaves o hubs innecesarios
-\n• Evite usar el teléfono mientras se escribe
-\n• Reemplace los adaptadores USB On-The-Go defectuosos
-\n
-\nSi el problema persiste, por favor envíe un mensaje en GitHub.</string>
+
     <string name="reporting_issues">Reportando problemas</string>
     <string name="reporting_issues_text">Los problemas pueden ser reportados en GitHub: 
 \nhttps://github.com/EtchDroid/EtchDroid/issues</string>
@@ -112,9 +102,8 @@
     <string name="job_failed">El trabajo falló.</string>
     <string name="file_unknown">(desconocido)</string>
     <string name="write_x_to_y">Escribir %1$s a %2$s</string>
-    <string name="i2o_action_name">Copiar datos de %1$s a %2%s</string>
+    <string name="i2o_action_name">Copiar datos de %1$s a %2$s</string>
     <string name="step_x_of_y">Paso %1$d de %2$d</string>
-    <string name="libusb_license_desc">Una biblioteca multiplataforma para acceder a los dispositivos USB</string>
     <string name="broken_usb_text">Si Android dice que hay un problema con su unidad USB o que no es compatible después de usar EtchDroid, lea esto.</string>
     <string name="broken_usb_title">¿Unidad USB no compatible\?</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
-    <string name="app_name">EtchDroid</string>
     <string name="flash_dd_usb_api">Écrire l\'image directement sur le disque (en utilisant l\'API Android)</string>
     <string name="flash_dmg_api">Restauration d\'une image DMG macOS sur le disque (en utilisant l\'API Android)</string>
     <string name="flash_unetbootin">Flash style Unetbootin (MBR uniquement, nécessite le root)</string>
@@ -20,38 +19,13 @@
     <string name="notif_initializing">Initialisation…</string>
     <string name="notif_writing_img">Écriture de l\'image…</string>
     <string name="image_is_not_dmg">L\'image sélectionnée n\'est pas une image DMG valide (elle est peut être corrompue)</string>
-    <string name="ptt_aix">IBM AIX</string>
-    <string name="ptt_amiga">AMIGA</string>
-    <string name="ptt_bsd">BSD</string>
-    <string name="ptt_dvh">DVH</string>
     <string name="ptt_gpt">Table de partitions GUID (GPT)</string>
     <string name="ptt_loop">Aucun</string>
     <string name="ptt_mac">Table de partitions Apple (APT)</string>
-    <string name="ptt_msdos">Master Boot Record (MS-DOS)</string>
-    <string name="ptt_pc98">PC98</string>
-    <string name="ptt_sun">Sun</string>
-    <string name="fs_fat12">FAT12</string>
-    <string name="fs_fat16">FAT16</string>
-    <string name="fs_fat32">FAT32</string>
-    <string name="fs_exfat">ExFAT</string>
-    <string name="fs_ntfs">NTFS</string>
-    <string name="fs_refs">ReFS</string>
-    <string name="fs_hfs">macOS HFS</string>
-    <string name="fs_hfsplus">macOS HFS+</string>
-    <string name="fs_apfs">Système de fichiers Apple (APFS)</string>
     <string name="fs_apt_data">Données APT</string>
-    <string name="fs_iso9660">ISO 9660</string>
-    <string name="fs_ext2">Linux ext2</string>
-    <string name="fs_ext3">Linux ext3</string>
-    <string name="fs_ext4">Linux Ext4</string>
-    <string name="fs_btrfs">Btrfs</string>
-    <string name="fs_f2fs">f2fs</string>
     <string name="fs_luks">Cryptage LUKS</string>
     <string name="fs_linux_swap">Linux swap</string>
     <string name="fs_linux_lvm_pv">Linux volume physique LVM2</string>
-    <string name="fs_ufs">UFS</string>
-    <string name="fs_xfs">XFS</string>
-    <string name="fs_zfs">ZFS</string>
     <string name="fs_free">Espace libre</string>
     <string name="fs_unformatted">Non formaté</string>
     <string name="fs_unknown">Inconnu</string>
@@ -59,11 +33,8 @@
     <string name="fs_label">Libellé</string>
     <string name="fs_type">Type</string>
     <string name="part_size">Taille</string>
-    <string name="license_gpl3_name">GNU GPLv3</string>
     <string name="this_app">Cette application</string>
-    <string name="license_apache_name">Apache 2.0</string>
     <string name="libaums_desc">Implémentation du bloc de périphérique USB dans l\'espace utilisateur</string>
-    <string name="license_gpl2">GNU GPLv2</string>
     <string name="license_bzip2">Personnalisée, inspirée de BSD</string>
     <string name="license_custom">Personnalisé</string>
     <string name="about">À propos</string>
@@ -88,7 +59,6 @@
     <string name="dataloss_confirmation_dialog_message">Si vous continuez, l\'image sélectionnée sera écrite et toutes les données stockées sur la clé USB seront perdues à jamais.</string>
     <string name="warning">Avertissement</string>
     <string name="cancel">Annuler</string>
-    <string name="license_mpl_2_0">MPL-2.0</string>
     <string name="storagechooser_desc">Sélecteur de fichier DMG</string>
     <string name="result_channel_desc">Utilisé pour afficher le résultat d\'une opération d\'écriture aboutie</string>
     <string name="result_channel_name">Notifications pour les résultats d\'écriture sur l\'USB</string>
@@ -98,17 +68,7 @@
     <string name="success_notif_content_text">%1$s a été écrit sur %2$s avec succès</string>
     <string name="troubleshooting_info">Informations de débogage</string>
     <string name="operation_failed_because">L\'opération n\'a pas pu aboutir à cause de l\'erreur suivante :</string>
-    <string name="troubleshoot_sock_op_on_non_sock">C\'est une erreur courante. Cela se produit généralement lorsque la clé USB est débranchée pendant l\'écriture ou lorsqu\'elle est connectée via un hub USB. Sur certains périphériques, il peut y avoir un bogue dans le sous-système USB d\'Android : en général, un redémarrage le corrigera pour un certain temps. 
-\n
-\nEssayez ceci :
-\n- Débranchez et rebranchez le périphérique USB, puis redémarrez l\'application.
-\n- Redémarrez votre appareil (vraiment, essayez-le)
-\n- Essayez une autre clé USB
-\n- Évitez d\'utiliser inutilement des adaptateurs, des dongles ou des hubs.
-\n- Évitez d\'utiliser votre téléphone pendant l\'écriture
-\n- Remplacez les adaptateurs USB On-The-Go défectueux.
-\n
-\nSi le problème persiste, merci d\'ouvrir un ticket sur GitHub.</string>
+
     <string name="reporting_issues">Rapporter des erreurs</string>
     <string name="reporting_issues_text">Les erreurs peuvent être rapportés sur GitHub :
 \nhttps://github.com/Depau/EtchDroid/issues</string>
@@ -128,30 +88,11 @@
 
 
     <string name="library_AndroidX_libraryDescription">AndroidX est une amélioration majeure de la bibliothèque de support Android d\'origine et offre une rétrocompatibilité entre les versions d\'Android</string>
-    <string name="library_AndroidX_libraryWebsite">https://developer.android.com/jetpack/androidx/</string>
-    <string name="library_AndroidX_libraryVersion">1.0.1</string>
-    <string name="library_AndroidX_isOpenSource">true</string>
-    <string name="library_AndroidX_repositoryLink">https://android.googlesource.com/platform/frameworks/support/+/androidx-master-dev/</string>
-    <string name="library_KotlinStdlib_author">JetBrains</string>
-    <string name="library_KotlinStdlib_authorWebsite">https://kotlinlang.org/</string>
     <string name="library_KotlinStdlib_libraryName">Kotlin Standard Library</string>
     <string name="library_KotlinStdlib_libraryDescription">The Kotlin Standard Library provides living essentials for everyday work with Kotlin</string>
-    <string name="library_KotlinStdlib_libraryWebsite">https://kotlinlang.org/api/latest/jvm/stdlib/index.html</string>
-    <string name="library_KotlinStdlib_libraryVersion">1.2.71</string>
-    <string name="library_KotlinStdlib_isOpenSource">true</string>
-    <string name="library_KotlinStdlib_repositoryLink">https://github.com/JetBrains/kotlin/tree/master/libraries/stdlib</string>
-    <string name="license_kotlin_stdlib">apache_2_0</string>
 
 
-    <string name="library_Material_author">Google</string>
-    <string name="library_Material_authorWebsite">https://material.io/develop/</string>
-    <string name="library_Material_libraryName">Material Components</string>
     <string name="library_Material_libraryDescription">Make beautiful products, faster. Material is a design system – backed by open-source code – that helps teams build digital experiences</string>
-    <string name="library_Material_libraryWebsite">https://material.io/develop/android/</string>
-    <string name="library_Material_libraryVersion">1.1.0-alpha01</string>
-    <string name="library_Material_isOpenSource">true</string>
-    <string name="library_Material_repositoryLink">https://github.com/material-components/material-components-android</string>
-    <string name="license_material_library">apache_2_0</string>
 
     <string name="app_desc">Une application pour écrire les images de systèmes d\'exploitation sur les clés USB, pas de root requis.</string>
     <string name="buy_me_a_coffee">M\'acheter un café</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">EtchDroid</string>
     <string name="flash_dd_usb_api">Scrivi immagine su dispositivo USB (utilizzando le API di Android)</string>
     <string name="flash_dmg_api">Ripristina immagine DMG macOS su dispositivo USB (utilizzando le API di Android)</string>
     <string name="flash_unetbootin">Scrittura in modalità Unetbootin (solo MBR, richiede root)</string>
@@ -20,38 +19,13 @@
     <string name="notif_initializing">Inizializzazione…</string>
     <string name="notif_writing_img">Scrittura immagine…</string>
     <string name="image_is_not_dmg">L\'immagine selezionata non è in formato DMG (probabilmente è corrotta)</string>
-    <string name="ptt_aix">IBM AIX</string>
-    <string name="ptt_amiga">AMIGA</string>
-    <string name="ptt_bsd">BSD</string>
-    <string name="ptt_dvh">DVH</string>
     <string name="ptt_gpt">Tabella Partizioni GUID (GPT)</string>
     <string name="ptt_loop">Nessuna</string>
     <string name="ptt_mac">Tabella Partizioni Apple (APT)</string>
-    <string name="ptt_msdos">Master Boot Record (MSDOS)</string>
-    <string name="ptt_pc98">PC98</string>
-    <string name="ptt_sun">Sun</string>
-    <string name="fs_fat12">FAT12</string>
-    <string name="fs_fat16">FAT16</string>
-    <string name="fs_fat32">FAT32</string>
-    <string name="fs_exfat">ExFAT</string>
-    <string name="fs_ntfs">NTFS</string>
-    <string name="fs_refs">ReFS</string>
-    <string name="fs_hfs">macOS HFS</string>
-    <string name="fs_hfsplus">macOS HFS+</string>
-    <string name="fs_apfs">Apple Filesystem (APFS)</string>
     <string name="fs_apt_data">Dati APT</string>
-    <string name="fs_iso9660">ISO 9660</string>
-    <string name="fs_ext2">Linux Ext2</string>
-    <string name="fs_ext3">Linux Ext3</string>
-    <string name="fs_ext4">Linux Ext4</string>
-    <string name="fs_btrfs">Btrfs</string>
-    <string name="fs_f2fs">f2fs</string>
     <string name="fs_luks">LUKS cifrato</string>
     <string name="fs_linux_swap">Linux swap</string>
     <string name="fs_linux_lvm_pv">Volume fisico Linux LVM2</string>
-    <string name="fs_ufs">UFS</string>
-    <string name="fs_xfs">XFS</string>
-    <string name="fs_zfs">ZFS</string>
     <string name="fs_free">Spazio libero</string>
     <string name="fs_unformatted">Non formattato</string>
     <string name="fs_unknown">Sconosciuto</string>
@@ -59,11 +33,8 @@
     <string name="fs_label">Etichetta</string>
     <string name="fs_type">Tipo</string>
     <string name="part_size">Dimensioni</string>
-    <string name="license_gpl3_name">GNU GPLv3</string>
     <string name="this_app">Quest\'app</string>
-    <string name="license_apache_name">Apache 2.0</string>
     <string name="libaums_desc">Implementazione dispositivi a blocchi in userspace</string>
-    <string name="license_gpl2">GNU GPLv2</string>
     <string name="license_bzip2">Simile a BSD</string>
     <string name="license_custom">Personalizzata</string>
     <string name="about">Informazioni</string>
@@ -87,7 +58,6 @@
     <string name="dataloss_confirmation_dialog_message">Se continui, l\'immagine verrà scritta e tutti i dati attualmente memorizzati sul dispositivo USB andranno persi!</string>
     <string name="warning">Attenzione</string>
     <string name="cancel">Annulla</string>
-    <string name="license_mpl_2_0">MPL-2.0</string>
     <string name="storagechooser_desc">Selettore file DMG</string>
     <string name="result_channel_desc">Utilizzato per mostrare il risultato di un\'operazione di scrittura terminata</string>
     <string name="result_channel_name">Risultati scrittura USB</string>
@@ -97,17 +67,7 @@
     <string name="success_notif_content_text">%1$s scritto con successo su %2$s</string>
     <string name="troubleshooting_info">Risoluzione dei problemi</string>
     <string name="operation_failed_because">L\'operazione non è stata completata a causa del seguente errore:</string>
-    <string name="troubleshoot_sock_op_on_non_sock">Questo è un errore comune. In genere succede quando il dispositivo USB viene scollegato mentre è in corso una scrittura o quando è connesso attraverso un hub USB. Su qualche dispositivo, invece, è presente un problema nel sottosistema USB di Android: solitamente un riavvio lo risolve per un po\' di tempo.
-\n
-\nProva questi suggerimenti:
-\n• Stacca e riattacca il dispositivo USB, quindi riavvia l\'app
-\n• Riavvia il dispositivo (davvero, fallo)
-\n• Prova un\'altro dispositivo USB
-\n• Evita di usare adattatori o hub se non necessari
-\n• Evita di usare il telefono mentre sta scrivendo immagini
-\n• Sostituisci un adattatore USB On-The-Go difettoso
-\n
-\nSe il problema persiste segnalacelo su GitHub cosicché possiamo sistemarlo.</string>
+
     <string name="reporting_issues">Segnalazione dei problemi</string>
     <string name="reporting_issues_text">I problemi possono essere segnalati su GitHub:\nhttps://github.com/Depau/EtchDroid/issues</string>
     <string name="write_failed">Scrittura fallita</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -34,11 +34,9 @@
     <string name="fs_type">Type</string>
     <string name="part_size">Størrelse</string>
     <string name="this_app">Dette programmet</string>
-    <string name="libaums_license_desc">Implementasjon av USB-blokkenhet i brukerrom</string>
     <string name="license_bzip2" comment="This string must be very short: it is displayed in a small badge and long strings will be truncated">Egendefinert BSD-lignende</string>
     <string name="license_custom" comment="This string must be very short: it is displayed in a small badge and long strings will be truncated">Egendefinert</string>
     <string name="about">Om</string>
-    <string name="dmg2img_license_desc">Konverterer sammenpakkede Apple®-DMG-oppstartsfiler</string>
     <string name="title_activity_usb_drive_picker">Velg USB-enhet</string>
     <string name="title_activity_confirmation">Klar til skriving</string>
     <string name="cannot_write">Kan ikke skrive oppstartsfil til USB-disk</string>
@@ -57,7 +55,6 @@
     <string name="dataloss_confirmation_dialog_message">Hvis du fortsetter vil valgt oppstartsfil bli skrevet og all data som er lagret på USB-disken gå tapt for alltid!</string>
     <string name="warning">Advarsel</string>
     <string name="cancel">Avbryt</string>
-    <string name="storagechooser_license_description">DMG-filvelger</string>
     <string name="result_channel_desc">Brukt til visning av resultat for fullført skriving</string>
     <string name="result_channel_name">Merknadsresultat for USB-skriving</string>
     <string name="failed_tap_for_info">Mislyktes • Trykk for info</string>
@@ -101,10 +98,8 @@
     <string name="write_x_to_y">Skriv %1$s til %2$s</string>
     <string name="i2o_action_name">Kopier data fra %1$s til %2$s</string>
     <string name="step_x_of_y">Steg %1$d av %2$d</string>
-    <string name="libaums_wrapper_license_desc">Et litte mellomlegg som gjør at libaums fungerer bedre med EtchDroid</string>
     <string name="could_not_access_usb_error">Fikk ikke tilgang til USB-enhet. Kanskje du kjørte programmet tidligere og det kræsjet\? Fjern og sett inn i USB-lagringsenheten, start så programmet på ny.</string>
     <string name="dmg_alert_dialog_text">I de fleste fall kan DMG-avbildninger gjennopprettes uten plunder, men noen ganger er det uoverenstemmelser. Dette er en advarsel.</string>
-    <string name="libusb_license_desc">Et multiplattformsbibliotek for tilgang til USB-enheter</string>
     <string name="broken_usb_text">Hvis Android sier det er et problem med din USB-lagringsenhet, eller at den er ustøttet etter å ha brukt EtchDroid, les dette.</string>
     <string name="broken_usb_title">Ustøttet USB-lagringsenhet\?</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -34,13 +34,9 @@
     <string name="fs_type">Type</string>
     <string name="part_size">Grootte</string>
     <string name="this_app">Deze app</string>
-    <string name="libaums_license_desc">Userspace USB-blokapparaatimplementatie</string>
-    <string name="libusb_license_desc">Een cross-platform bibliotheek voor het benaderen van USB-apparaten</string>
-    <string name="libaums_wrapper_license_desc">Een kleine pleister om libaums beter te laten werken met EtchDroid</string>
     <string name="license_bzip2" comment="This string must be very short: it is displayed in a small badge and long strings will be truncated">Aangepaste BSD-achtige licentie</string>
     <string name="license_custom" comment="This string must be very short: it is displayed in a small badge and long strings will be truncated">Aangepast</string>
     <string name="about">Over</string>
-    <string name="dmg2img_license_desc">Converteert ingepakte Apple® DMG-schijfkopieën</string>
     <string name="title_activity_usb_drive_picker">USB-apparaat kiezen</string>
     <string name="title_activity_confirmation">Klaar om weg te schrijven</string>
     <string name="cannot_write">Kan schijfkopie niet wegschrijven naar USB-apparaat</string>
@@ -62,7 +58,6 @@
 \n verloren!</string>
     <string name="warning">Waarschuwing</string>
     <string name="cancel">Annuleren</string>
-    <string name="storagechooser_license_description">DMG-bestandskiezer</string>
     <string name="result_channel_desc">Wordt gebruikt om het resultaat van een afgeronde schrijfactie te tonen</string>
     <string name="result_channel_name">Resultaatmeldingen</string>
     <string name="failed_tap_for_info">Mislukt • Druk hier voor meer informatie</string>
@@ -112,8 +107,6 @@
     <string name="license_dmg2img_desc">Converteert Apple® DMG-schijfafbeeldingen met compressie</string>
     <string name="license_custom_foss">Ander soort FOSS</string>
     <string name="license_other">Anders</string>
-    <string name="license_gpl2" translatable="false">gpl-2.0</string>
-    <string name="license_gpl3" translatable="false">gpl-3.0</string>
     <string name="libusb_desc">Een cross-platformbibliotheek om USB-apparaten te benaderen</string>
     <string name="libaums_wrapper_desc">Een kleine toevoeging om libaums beter te laten werken met EtchDroid</string>
     <string name="libaums_desc">Userspace USB-blokapparaatimplementatie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -67,17 +67,7 @@
     <string name="success_notif_content_text">%1$s gravado com sucesso para %2$s</string>
     <string name="troubleshooting_info">Informações de solução de problemas</string>
     <string name="operation_failed_because">A operação não pôde ser concluída porque ocorreu o seguinte erro:</string>
-    <string name="troubleshoot_sock_op_on_non_sock">Este é um erro comum. Geralmente, isso acontece quando a unidade USB é desconectada enquanto está sendo gravada ou quando está conectada por meio de um hub USB. Em alguns dispositivos, pode haver um bug no subsistema USB do Android: geralmente, uma reinicialização consertará isso por algum tempo.
-\n
-\nTente isso:
-\n• Desconecte e reconecte o dispositivo USB e reinicie o aplicativo
-\n• Reinicialize seu dispositivo (sério, tente isso)
-\n• Tente outra unidade USB
-\n• Evite usar adaptadores desnecessários, dongles ou hubs
-\n• Evite usar o telefone enquanto ele estiver gravando
-\n• Substitua os adaptadores USB On-The-Go defeituosos
-\n
-\nSe o problema persistir, registre um relatório de problema no GitHub.</string>
+
     <string name="reporting_issues">Relatando problemas</string>
     <string name="reporting_issues_text">Problemas podem ser relatados no GitHub:
 \nhttps://github.com/EtchDroid/EtchDroid/issues</string>
@@ -100,7 +90,6 @@
     <string name="library_Material_libraryDescription">Faça produtos bonitos, mais rápido. Material é um sistema de design - apoiado por código-fonte aberto - que ajuda as equipes a construir experiências digitais</string>
     <string name="app_desc">Um aplicativo para gravar imagens de SO em unidades USB, no Android, sem precisar de root.</string>
     <string name="buy_me_a_coffee">Me compre um café</string>
-    <string name="libaums_wrapper_license_desc">Um pequeno calço para fazer com que os libaums funcionem melhor com o EtchDroid</string>
     <string name="failed_tap_for_info">Falha · Toque para info</string>
     <string name="notif_channel_job_progress_desc" comment="Notification channel description">Usado para mostrar o progresso do trabalho atual</string>
     <string name="notif_channel_job_progress_name">Progresso da operação</string>
@@ -117,5 +106,4 @@
     <string name="step_x_of_y">Em %1$d de %2$d</string>
     <string name="broken_usb_title">Unidade USB sem suporte\?</string>
     <string name="broken_usb_text">Se o Android disser que há um problema com a sua unidade USB ou que não é suportado após o uso do EtchDroid, leia isso.</string>
-    <string name="libusb_license_desc">Uma biblioteca de plataforma cruzada para acessar dispositivos USB</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -77,8 +77,6 @@
     <string name="failed_tap_for_info">Eșuat • Atingeți pentru info</string>
     <string name="result_channel_name">Notificări de rezultat de scriere pe unitate USB</string>
     <string name="here_be_dragons">Hic sunt dracones</string>
-    <string name="libusb_license_desc">O multiplatformă bibliotecă pentru a accesa unități USB</string>
-    <string name="storagechooser_license_description">Selector de fișiere DMG</string>
     <string name="cancel">Anulare</string>
     <string name="warning">Avertizare</string>
     <string name="dataloss_confirmation_dialog_message">Dacă continui, imaginea selectat va fi scris și toate datele pe discul USB vor fi pierdut pentru totdeauna!</string>
@@ -94,5 +92,4 @@
     <string name="could_not_access_usb_error">Nu poate accesare dispozitivul USB. Poate că ar fi executat aplicație înainte și a închis neașteptat\? Scoateți și reintroduceți discul USB, apoi reporniți aplicarea.</string>
     <string name="partition_table_title">Tabela de partiții:</string>
     <string name="check_notification_progress">Vezi notificare pentru progres</string>
-    <string name="dmg2img_license_desc">Convertește imagini Apple® DMG comprimate</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -90,7 +90,6 @@
     <string name="this_app">Это приложение</string>
     <string name="title_activity_confirmation">Готов к записи</string>
     <string name="title_activity_usb_drive_picker">Выбрать USB-накопитель</string>
-    <string name="troubleshoot_sock_op_on_non_sock">Это известная проблема. Обычно это происходит, когда USB-накопитель извлекается во время процедуры записи, когда он подключён через USB-разветвитель или когда накопитель просто не подключён к устройству. На некоторых устройствах такое поведения может быть вызвано багом USB подсистемы Android — попробуйте перезагрузить устройство.</string>
     <string name="troubleshooting_info">Сведения об устранении неполадок</string>
     <string name="uncompressed">(несжатый)</string>
     <string name="unknown_error">Неизвестная ошибка — попробуйте переподключить USB-накопитель или перезагрузить устройство. Пожалуйста, сообщите о проблеме на GitHub.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">EtchDroid</string>
     <string name="flash_dd_usb_api">Kalıbı doğrudan diske yaz (Android API kullanarak)</string>
     <string name="flash_dmg_api">macOS DMG kalıbını diske yaz (Android API kullanarak)</string>
     <string name="flash_unetbootin">Unetbootin tarzı yazma (yalnızca MBR, root gerektirir)</string>
@@ -20,38 +19,13 @@
     <string name="notif_initializing">Başlatılıyor…</string>
     <string name="notif_writing_img">Kalıp yazılıyor…</string>
     <string name="image_is_not_dmg">Seçilen kalıp bir DMG kalıbı değil (bozulmuş olabilir)</string>
-    <string name="ptt_aix">IBM AIX</string>
-    <string name="ptt_amiga">AMIGA</string>
-    <string name="ptt_bsd">BSD</string>
-    <string name="ptt_dvh">DVH</string>
     <string name="ptt_gpt">GUID Bölüm Tablosu (GPT)</string>
     <string name="ptt_loop">Hiçbiri</string>
     <string name="ptt_mac">Apple Bölüm Tablosu (APT)</string>
-    <string name="ptt_msdos">Master Boot Record (MS-DOS)</string>
-    <string name="ptt_pc98">PC98</string>
-    <string name="ptt_sun">Sun</string>
-    <string name="fs_fat12">FAT12</string>
-    <string name="fs_fat16">FAT16</string>
-    <string name="fs_fat32">FAT32</string>
-    <string name="fs_exfat">ExFAT</string>
-    <string name="fs_ntfs">NTFS</string>
-    <string name="fs_refs">ReFS</string>
-    <string name="fs_hfs">macOS HFS</string>
-    <string name="fs_hfsplus">macOS HFS+</string>
-    <string name="fs_apfs">Apple Dosya Sistemi (APFS)</string>
     <string name="fs_apt_data">APT veri</string>
-    <string name="fs_iso9660">ISO 9660</string>
-    <string name="fs_ext2">Linux Ext2</string>
-    <string name="fs_ext3">Linux Ext3</string>
-    <string name="fs_ext4">Linux Ext4</string>
-    <string name="fs_btrfs">Btrfs</string>
-    <string name="fs_f2fs">f2fs</string>
     <string name="fs_luks">LUKS şifrelenmiş</string>
     <string name="fs_linux_swap">Linux swap</string>
     <string name="fs_linux_lvm_pv">Linux LVM2 fiziksel aygıt</string>
-    <string name="fs_ufs">UFS</string>
-    <string name="fs_xfs">XFS</string>
-    <string name="fs_zfs">ZFS</string>
     <string name="fs_free">Boş alan</string>
     <string name="fs_unformatted">Biçimlendirilmemiş</string>
     <string name="fs_unknown">Bilinmeyen</string>
@@ -59,11 +33,8 @@
     <string name="fs_label">Etiket</string>
     <string name="fs_type">Tür</string>
     <string name="part_size">Boyut</string>
-    <string name="license_gpl3_name">GNU GPLv3</string>
     <string name="this_app">Bu uygulama</string>
-    <string name="license_apache_name">Apache 2.0</string>
     <string name="libaums_desc">Kullanıcı alanı USB blok aygıtı uygulaması</string>
-    <string name="license_gpl2">gpl-2.0</string>
     <string name="license_bzip2">Özel BSD benzeri</string>
     <string name="license_custom">Özel</string>
     <string name="about">Lisanslar</string>
@@ -87,7 +58,6 @@
     <string name="dataloss_confirmation_dialog_message">Devam ederseniz, seçtiğiniz kalıp diske yazılacak ve USB bellekteki tüm veriler sonsuza kadar yok olacak!</string>
     <string name="warning">Uyarı</string>
     <string name="cancel">İptal</string>
-    <string name="license_mpl_2_0">MPL-2.0</string>
     <string name="storagechooser_desc">DMG dosya seçici</string>
     <string name="result_channel_desc">Bitmiş bir yazma işleminin sonucunu göstermek için kullanılır</string>
     <string name="result_channel_name">USB yazma sonucu bildirimleri</string>
@@ -97,7 +67,6 @@
     <string name="success_notif_content_text">%1$s başarıyla %2$s üzerine yazıldı</string>
     <string name="troubleshooting_info">Y</string>
     <string name="operation_failed_because">İşlem aşağıdaki hatadan dolayı tamamlanamadı:</string>
-    <string name="troubleshoot_sock_op_on_non_sock">Bu yaygın bir hatadır. genellikle yazma sırasında USB belleğin çıkarılması, yada bir USB çoklayıcı kullanarak bağlanması ile oluşur. Bazı cihazlarda bu bir Android USB altsistemi hatası olabilir: çoğu zaman cihaz yeniden başlatıldığında çözülebilir. \n\nBunları deneyin:\n• USB aygıtınızı çıkarıp takın, sonra uygulamayı yeniden başlatın.\n• Cihazınızı yeniden başlatın. (evet, deneyin.)\n• Başka bir USB aygıtı deneyin.\n• Gereksiz adaptörler, çoklayıcılar vb. kullanmaktan kaçının.\n• YAzma sırasında cihazınızı kullanmaktan kaçının.\n• Hasarlı OTG kablonuzu değiştirin.\n\nEğer sorununuz çözülmüyorsa GitHub üzerinden sorun bildirimi yapın.</string>
     <string name="reporting_issues">Sorun bildirimi</string>
     <string name="reporting_issues_text">Sorunlar GitHub üzerinden bildirilebilir:\nhttps://github.com/Depau/EtchDroid/issues</string>
     <string name="write_failed">Yazma başarısız</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">EtchDroid</string>
     <string name="flash_dd_usb_api">直接写入镜像到磁盘(使用Android API)</string>
     <string name="flash_dmg_api">将macOS DMG映像还原到磁盘(使用Android API)</string>
     <string name="flash_unetbootin">Unetbootin-style flash (仅限 MBR, 需要 root)</string>
@@ -20,38 +19,13 @@
     <string name="notif_initializing">初始化中…</string>
     <string name="notif_writing_img">写入镜像中…</string>
     <string name="image_is_not_dmg">所选文件不是DMG镜像（可能已损坏）</string>
-    <string name="ptt_aix" translatable="false">IBM AIX</string>
-    <string name="ptt_amiga" translatable="false">AMIGA</string>
-    <string name="ptt_bsd" translatable="false">BSD</string>
-    <string name="ptt_dvh" translatable="false">DVH</string>
     <string name="ptt_gpt">GUID分区表(GPT)</string>
     <string name="ptt_loop">无</string>
     <string name="ptt_mac">Apple分区表(APT)</string>
-    <string name="ptt_msdos" translatable="false">Master Boot Record (MSDOS)</string>
-    <string name="ptt_pc98" translatable="false">PC98</string>
-    <string name="ptt_sun" translatable="false">Sun</string>
-    <string name="fs_fat12" translatable="false">FAT12</string>
-    <string name="fs_fat16" translatable="false">FAT16</string>
-    <string name="fs_fat32" translatable="false">FAT32</string>
-    <string name="fs_exfat" translatable="false">ExFAT</string>
-    <string name="fs_ntfs" translatable="false">NTFS</string>
-    <string name="fs_refs" translatable="false">ReFS</string>
-    <string name="fs_hfs" translatable="false">macOS HFS</string>
-    <string name="fs_hfsplus" translatable="false">macOS HFS+</string>
-    <string name="fs_apfs" translatable="false">Apple Filesystem (APFS)</string>
     <string name="fs_apt_data">APT 数据</string>
-    <string name="fs_iso9660" translatable="false">ISO 9660</string>
-    <string name="fs_ext2" translatable="false">Linux Ext2</string>
-    <string name="fs_ext3" translatable="false">Linux Ext3</string>
-    <string name="fs_ext4" translatable="false">Linux Ext4</string>
-    <string name="fs_btrfs" translatable="false">Btrfs</string>
-    <string name="fs_f2fs" translatable="false">f2fs</string>
     <string name="fs_luks">LUKS已加密(磁盘加密)</string>
     <string name="fs_linux_swap">Linux swap(虚拟内存)</string>
     <string name="fs_linux_lvm_pv">Linux LVM2 物理卷</string>
-    <string name="fs_ufs" translatable="false">UFS</string>
-    <string name="fs_xfs" translatable="false">XFS</string>
-    <string name="fs_zfs" translatable="false">ZFS</string>
     <string name="fs_free">空闲空间</string>
     <string name="fs_unformatted">未格式化</string>
     <string name="fs_unknown">未知</string>
@@ -59,13 +33,10 @@
     <string name="fs_label">标签</string>
     <string name="fs_type">类型</string>
     <string name="part_size">大小</string>
-    <string name="license_gpl3_name" translatable="false">GNU GPLv3</string>
     <string name="this_app">此app</string>
-    <string name="license_apache_name" translatable="false">Apache 2.0</string>
     <string name="libaums_desc">USB相关驱动支持</string>
     <string name="libusb_desc">A cross-platform library to access USB devices</string>
     <string name="libaums_wrapper_desc">A little shim to make libaums work better with EtchDroid</string>
-    <string name="license_gpl2" translatable="false">GNU GPLv2</string>
     <string name="license_bzip2" comment="This string must be very short: it is displayed in a small badge and long strings will be truncated">自定义 BSD-like</string>
     <string name="license_custom" comment="This string must be very short: it is displayed in a small badge and long strings will be truncated">自定义</string>
     <string name="about">关于</string>
@@ -90,7 +61,6 @@
     <string name="dataloss_confirmation_dialog_message">如果继续，将写入所选镜像，并且USB设备上存储的现有数据被格式化！请注意备份！</string>
     <string name="warning">警告⚠</string>
     <string name="cancel">取消</string>
-    <string name="license_mpl_2_0" translatable="false">MPL-2.0</string>
     <string name="storagechooser_desc">DMG 文件选择</string>
     <string name="result_channel_desc">用于显示完成写入的结果</string>
     <string name="result_channel_name">USB写入结果通知</string>
@@ -117,38 +87,12 @@
     <string name="cannot_find_file_in_storage">无法在内部存储中找到文件。尝试在应用内打开它。</string>
     <string name="storage_permission_required">读取DMG镜像需要存储权限</string>
     <!-- AndroidX Jetpack -->
-    <string name="define_AndroidX" translatable="false" />
-    <string name="library_AndroidX_author" translatable="false">AOSP</string>
-    <string name="library_AndroidX_authorWebsite" translatable="false">https://developer.android.com</string>
-    <string name="library_AndroidX_libraryName" translatable="false">AndroidX Jetpack</string>
     <string name="library_AndroidX_libraryDescription">AndroidX 对原始 Android 支持库进行了重大改进，并与各个 Android 版本向后兼容</string>
-    <string name="library_AndroidX_libraryWebsite" translatable="false">https://developer.android.com/jetpack/androidx/</string>
-    <string name="library_AndroidX_libraryVersion" translatable="false">1.0.1</string>
-    <string name="library_AndroidX_isOpenSource" translatable="false">true</string>
-    <string name="library_AndroidX_repositoryLink" translatable="false">https://android.googlesource.com/platform/frameworks/support/+/androidx-master-dev/</string>
-    <string name="license_androidx_library" translatable="false">apache_2_0</string>
     <!-- Kotlin Standard Library -->
-    <string name="define_KotlinStdlib" translatable="false" />
-    <string name="library_KotlinStdlib_author" translatable="false">JetBrains</string>
-    <string name="library_KotlinStdlib_authorWebsite" translatable="false">https://kotlinlang.org/</string>
     <string name="library_KotlinStdlib_libraryName">Kotlin Standard Library</string>
     <string name="library_KotlinStdlib_libraryDescription">The Kotlin Standard Library provides living essentials for everyday work with Kotlin</string>
-    <string name="library_KotlinStdlib_libraryWebsite" translatable="false">https://kotlinlang.org/api/latest/jvm/stdlib/index.html</string>
-    <string name="library_KotlinStdlib_libraryVersion" translatable="false">1.2.71</string>
-    <string name="library_KotlinStdlib_isOpenSource" translatable="false">true</string>
-    <string name="library_KotlinStdlib_repositoryLink" translatable="false">https://github.com/JetBrains/kotlin/tree/master/libraries/stdlib</string>
-    <string name="license_kotlin_stdlib" translatable="false">apache_2_0</string>
     <!-- Material Components -->
-    <string name="define_Material" translatable="false" />
-    <string name="library_Material_author" translatable="false">Google</string>
-    <string name="library_Material_authorWebsite" translatable="false">https://material.io/develop/</string>
-    <string name="library_Material_libraryName" translatable="false">Material Components</string>
     <string name="library_Material_libraryDescription">Material是一个设计系统 - 由开源代码支持 - 帮助开发者构建制作精美的产品</string>
-    <string name="library_Material_libraryWebsite" translatable="false">https://material.io/develop/android/</string>
-    <string name="library_Material_libraryVersion" translatable="false">1.1.0-alpha01</string>
-    <string name="library_Material_isOpenSource" translatable="false">true</string>
-    <string name="library_Material_repositoryLink" translatable="false">https://github.com/material-components/material-components-android</string>
-    <string name="license_material_library" translatable="false">apache_2_0</string>
     <string name="app_desc">在Android上将各种映像写入USB的应用，无需root权限。</string>
     <string name="buy_me_a_coffee">捐赠</string>
     <string name="notif_channel_job_progress_desc" comment="Notification channel description">用于显示当前处理的进度</string>
@@ -160,7 +104,6 @@
     <string name="resuming_job">从检查点恢复…</string>
     <string name="done">完成!</string>
     <string name="job_failed">处理失败.</string>
-    <string name="empty_string" translatable="false">%s</string>
     <string name="file_unknown">(未知)</string>
     <string name="write_x_to_y">写入 %1$s 到 %2$s</string>
     <string name="i2o_action_name">"从\"%1$s\" 复制数据到 \"%2$s"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,7 +148,7 @@
     <string name="empty_string" translatable="false">%s</string>
     <string name="file_unknown">(unknown)</string>
     <string name="write_x_to_y">Write %1$s to %2$s</string>
-    <string name="i2o_action_name">"Copy data from "%1$s" to "%2$s"</string>
+    <string name="i2o_action_name">Copy data from %1$s to %2$s</string>
     <string name="step_x_of_y">Step %1$d of %2$d</string>
     <!--  About  -->
     <string name="fdroid" translatable="false">F-Droid</string>


### PR DESCRIPTION
There are a lot of translations with an attribute `translatable="false"`. 

`troubleshoot_sock_op_on_non_sock` exists in translations but doesn't exist in main `app/src/main/res/values/strings.xml`