### PR TITLE
Dark theme fix

### DIFF
--- a/app/src/main/java/eu/depau/etchdroid/ui/activities/ActivityBase.kt
+++ b/app/src/main/java/eu/depau/etchdroid/ui/activities/ActivityBase.kt
@@ -79,19 +79,17 @@ abstract class ActivityBase : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-            nightModeHelper = NightModeHelper(this, R.style.AppTheme)
-        }
+        nightModeHelper = NightModeHelper(this, R.style.MaterialAppTheme)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         // Inflate the menu; this adds items to the action bar if it is present.
         menuInflater.inflate(R.menu.menu_main, menu)
 
-        // Hide night mode menu on Android 10 as it causes weird issues
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            menu.findItem(R.id.action_nightmode).isVisible = false
+        menu.findItem(R.id.action_nightmode).title = if (isNightMode) {
+            getString(R.string.nightmode_night)
+        } else {
+            getString(R.string.nightmode)
         }
 
         return true

--- a/app/src/main/java/eu/depau/etchdroid/ui/misc/NightModeHelper.kt
+++ b/app/src/main/java/eu/depau/etchdroid/ui/misc/NightModeHelper.kt
@@ -3,6 +3,7 @@ package eu.depau.etchdroid.ui.misc
 import android.content.SharedPreferences
 import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
 import java.lang.ref.WeakReference
 
@@ -94,10 +95,12 @@ class NightModeHelper {
     private fun updateConfig(uiNightMode: Int) {
         val activity = mActivity!!.get()
                 ?: throw IllegalStateException("Activity went away while switching theme")
-        val newConfig = Configuration(activity.resources.configuration)
-        newConfig.uiMode = newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()
-        newConfig.uiMode = newConfig.uiMode or uiNightMode
-        activity.resources.updateConfiguration(newConfig, null)
+
+        activity.delegate.localNightMode = when (uiNightMode) {
+            16 -> AppCompatDelegate.MODE_NIGHT_NO
+            32 -> AppCompatDelegate.MODE_NIGHT_YES
+            else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        }
         Companion.uiNightMode = uiNightMode
         mPrefs.edit()?.putInt(PREF_KEY, Companion.uiNightMode)?.apply()
     }

--- a/app/src/main/res/layout/activity_start.xml
+++ b/app/src/main/res/layout/activity_start.xml
@@ -51,14 +51,16 @@
                 style="@style/TextAppearance.AppCompat.Subhead"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/write_image_or_iso" />
+                android:text="@string/write_image_or_iso"
+                android:textColor="?attr/colorOnSurface" />
 
             <TextView
                 android:id="@+id/rawButtonDescription"
                 style="@style/TextAppearance.AppCompat.Caption"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/raw_image_desc" />
+                android:text="@string/raw_image_desc"
+                android:textColor="?attr/colorOnSurface" />
         </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -105,14 +107,16 @@
                 style="@style/TextAppearance.AppCompat.Subhead"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/write_apple_dmg" />
+                android:text="@string/write_apple_dmg"
+                android:textColor="?attr/colorOnSurface" />
 
             <TextView
                 android:id="@+id/dmgButtonDescription"
                 style="@style/TextAppearance.AppCompat.Caption"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/dmg_image_desc" />
+                android:text="@string/dmg_image_desc"
+                android:textColor="?attr/colorOnSurface" />
 
         </LinearLayout>
 
@@ -149,7 +153,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/default_gap"
-            android:text="@string/broken_usb_title" />
+            android:text="@string/broken_usb_title"
+            android:textColor="?attr/colorOnSurface" />
 
         <TextView
             android:id="@+id/buttonUsbDescription"
@@ -157,7 +162,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/default_gap"
-            android:text="@string/broken_usb_text" />
+            android:text="@string/broken_usb_text"
+            android:textColor="?attr/colorOnSurface" />
 
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Dark application theme. -->
-    <style name="MaterialAppTheme" parent="Theme.AppCompat">
+    <style name="MaterialAppTheme" parent="Theme.MaterialComponents.DayNight">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>


### PR DESCRIPTION
Fix is related to this commits: [1](https://github.com/EtchDroid/EtchDroid/commit/3d2c4e2b03c5ea8c8c31bc8ae336e7707639ef3a), [2](https://github.com/EtchDroid/EtchDroid/commit/fd671531b73c987bd9f27e071c7db85271d91930)


Works fine with API 21 (`min-sdk`) and 29 (`target-sdk`)

---
## Screenshots
### Android 10
![Screenshot from 2020-07-17 04-34-30](https://user-images.githubusercontent.com/16625266/87732664-14e2c480-c7e7-11ea-8a46-db7e70495da3.png)
![Screenshot from 2020-07-17 04-34-34](https://user-images.githubusercontent.com/16625266/87732666-17451e80-c7e7-11ea-9ff5-fb04542e162d.png)

---

### Android 5.0.2
![Screenshot from 2020-07-17 04-32-04](https://user-images.githubusercontent.com/16625266/87732674-1c09d280-c7e7-11ea-9374-820be9845423.png)
![Screenshot from 2020-07-17 04-32-11](https://user-images.githubusercontent.com/16625266/87732676-1d3aff80-c7e7-11ea-80b2-4f2ee00b3bcd.png)



