### PR TITLE
Refactor Notification Service Initialization

### DIFF
--- a/app/src/main/java/eu/depau/etchdroid/service/WorkerService.kt
+++ b/app/src/main/java/eu/depau/etchdroid/service/WorkerService.kt
@@ -84,7 +84,7 @@ class WorkerService : LifecycleService() {
 
     private val mNotificationManager by lazy {
         getSystemService(
-            Context.NOTIFICATION_SERVICE
+            NOTIFICATION_SERVICE
         ) as NotificationManager
     }
 


### PR DESCRIPTION
- Changed `getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager` to a lazy-initialized property `mNotificationManager`.
- Improves code readability and ensures the NotificationManager is only initialized when accessed.