### PR TITLE
Refactor JitPack URL to Single Variable

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,11 +1,13 @@
 @file:Suppress("UnstableApiUsage")
 
+val jitpackUrl = "https://jitpack.io"
+
 pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven(url = "https://jitpack.io")
+        maven(url = jitpackUrl)
     }
 }
 dependencyResolutionManagement {
@@ -13,7 +15,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://jitpack.io")
+        maven(url = jitpackUrl)
     }
 }
 rootProject.name = "EtchDroid"


### PR DESCRIPTION
- Simplified the Gradle script by defining the JitPack URL as a single variable `jitpackUrl`.
- Reused `jitpackUrl` in both `pluginManagement` and `dependencyResolutionManagement` sections.
- Improves maintainability by centralizing the URL definition, making it easier to update in the future if needed.