### PR TITLE
Refactor JVM Target Version to Use JavaVersion Constant

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,7 +79,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
     buildFeatures {
         compose = true


### PR DESCRIPTION
- Updated `kotlinOptions.jvmTarget` from hardcoded `"11"` to use `JavaVersion.VERSION_11.toString()`.
- This change improves readability and consistency by using `JavaVersion` constant, making it easier to manage or update the target version in the future.