### PR TITLE
Fix buffer mismatch check

### DIFF
--- a/app/src/main/java/eu/depau/etchdroid/service/WorkerService.kt
+++ b/app/src/main/java/eu/depau/etchdroid/service/WorkerService.kt
@@ -698,7 +698,12 @@ object WorkerServiceFlowImpl {
                         throw UsbCommunicationException(e)
                     }
 
-                    if (!fileBuffer.contentEquals(deviceBuffer)) {
+                    val mismatch = if (read == fileBuffer.size) {
+                        !fileBuffer.contentEquals(deviceBuffer)
+                    } else {
+                        !fileBuffer.copyOf(read).contentEquals(deviceBuffer.copyOf(read))
+                    }
+                    if (mismatch) {
                         Telemetry.captureMessage("Verification failed")
                         if (Build.VERSION.SDK_INT > 999999) {
                             // Prevent the compiler from optimizing out the buffers, for debugging


### PR DESCRIPTION
## Summary
- optimize verification so buffer copies only occur when the read count is less than the buffer size

## Testing
- `./gradlew test --no-daemon` *(fails: unresolved Firebase references)*

------
https://chatgpt.com/codex/tasks/task_e_6843386496848320ba5de2416a851d8a