### PR TITLE
remove obsolete SDK version check

### DIFF
--- a/app/src/main/java/eu/depau/etchdroid/utils/ktexts/UsbDeviceVidPidName.kt
+++ b/app/src/main/java/eu/depau/etchdroid/utils/ktexts/UsbDeviceVidPidName.kt
@@ -10,8 +10,4 @@ val UsbDevice.vidpid: String
 
 
 val UsbDevice.name: String
-    get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        "${this.manufacturerName} ${this.productName}"
-    } else {
-        this.deviceName
-    }
+    get() = "${this.manufacturerName} ${this.productName}"


### PR DESCRIPTION
I have noticed that minSdk in build.gradle.kts is 21. As I see, it means that this check is unnecessary because sdk version is always >= 21