### PR TITLE
Fix a11y focusability of "Write an image" button

### DIFF
--- a/app/src/main/java/eu/depau/etchdroid/ui/MainActivity.kt
+++ b/app/src/main/java/eu/depau/etchdroid/ui/MainActivity.kt
@@ -528,7 +528,7 @@ fun StartView(
                     headColor = if (darkMode) MaterialTheme.colorScheme.primary.toArgb()
                         .toLong() else MaterialTheme.colorScheme.primaryContainer.toArgb()
                         .toLong(),
-                ), contentDescription = "EtchDroid", tint = Color.Unspecified
+                ), contentDescription = null, tint = Color.Unspecified
             )
         },
         mainButton = {


### PR DESCRIPTION
Fixes #350.

For some reason, ExtendedFloatingActionButton seems to not be focusable via TalkBack if it's given an icon without a contentDescription, even when it has a text label it can use. I suspect this is a bug in Material 3, as I would expect this to work. But giving the icon a content description seems to fix and make the button focusable, so that seems like a fine enough workaround. This does that.

[Screen_recording_20260101_124749.webm](https://github.com/user-attachments/assets/d232dd07-82b9-4660-9593-2be20a6925e2)


This also removes the content description from the main logo as I don't think it really needs to be focusable (it's non-interactive and doesn't give any info).

Excellent app by the way, I found it super useful recently.