### PR TITLE
fix: preserve completed job state across rotation

### DIFF
--- a/app/src/main/java/eu/depau/etchdroid/ui/ProgressActivity.kt
+++ b/app/src/main/java/eu/depau/etchdroid/ui/ProgressActivity.kt
@@ -227,7 +227,7 @@ class ProgressActivity : ActivityBase() {
             mViewModel.refreshSettings(this)
         }
         refreshNotificationsPermission()
-        mViewModel.updateFromIntent(intent)
+        mViewModel.initializeFromIntent(intent)
 
         Telemetry.configureScope {
             val state = mViewModel.state.value

--- a/app/src/main/java/eu/depau/etchdroid/ui/ViewModel.kt
+++ b/app/src/main/java/eu/depau/etchdroid/ui/ViewModel.kt
@@ -243,6 +243,7 @@ data class ProgressActivityState(
 class ProgressActivityViewModel : ViewModel(), SettingChangeListener, IThemeViewModel<ProgressActivityState> {
     private val _state = MutableStateFlow(ProgressActivityState.Empty)
     override val state: StateFlow<ProgressActivityState> = _state.asStateFlow()
+    private var launchIntentConsumed = false
 
     override fun refreshSettings(settings: AppSettings) {
         _state.update {
@@ -257,7 +258,13 @@ class ProgressActivityViewModel : ViewModel(), SettingChangeListener, IThemeView
         _state.update { state }
     }
 
+    fun initializeFromIntent(intent: Intent) {
+        if (launchIntentConsumed) return
+        updateFromIntent(intent)
+    }
+
     fun updateFromIntent(intent: Intent) {
+        launchIntentConsumed = true
         val sourceUri = intent.safeParcelableExtra<Uri>("sourceUri")!!
         val status = intent.safeParcelableExtra<JobStatusInfo>("status")!!
 


### PR DESCRIPTION
## Summary

Prevent `ProgressActivity` from reverting a completed flashing job to an in-progress state after a configuration change, such as rotating the device.

## Cause

`ProgressActivity.onCreate()` reprocessed its original launch intent after every recreation. Because that intent contained the initial in-progress status, it overwrote the completed state retained by the activity’s `ViewModel`.

## Fix

Consume the launch intent only once per `ProgressActivityViewModel` instance. Live worker broadcasts continue to update progress normally, while process recreation still creates a new view model and consumes the available intent.

## Testing

- Built successfully with assembleFossDebug.
- Verified the success screen remains displayed after rotating the device.